### PR TITLE
fix: remove hard-coded paths to SlimerJS, make it work on Windows; fix options handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "slimerjs"
   ],
   "author": "Nicolas Froidure <nfroidure@elitwork.com>",
-  "dependencies": {},
+  "dependencies": {
+    "slimerjs": "^0.9"
+  },
   "peerDependencies": {
     "karma": ">=0.9"
   },
@@ -28,7 +30,7 @@
     "grunt-auto-release": "~0.0.2"
   },
   "contributors": [
-	  "Vojta Jina <vojta.jina@gmail.com>",
+    "Vojta Jina <vojta.jina@gmail.com>",
     "Friedel Ziegelmayer <friedel.ziegelmayer@gmail.com>",
     "Žilvinas Urbonas <zilvinas.urbon@gmail.com>",
     "Friedel Ziegelmayer <friedel.ziegelmayer@gmail.com>",


### PR DESCRIPTION
This bug fix
- declares the SlimerJS module explicitly as a dependency
- removes hard-coded paths for all platforms
- creates a working setup on Windows, runs SlimerJS without relying on slimerjs.bat
- properly processes options and config
- cleans up the code, structuring it like the PhantomJS launcher.

The Windows part of the fix was originally proposed by @bessdsv. Thank you!
